### PR TITLE
feat: add analytics, projects page, and review empty states

### DIFF
--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -10,6 +10,7 @@ const NAV_ITEMS = [
   { href: "/dashboard", label: "Today", icon: "📋" },
   { href: "/dashboard/priorities", label: "Priorities", icon: "🎯" },
   { href: "/dashboard/time-blocks", label: "Time Blocks", icon: "⏱️" },
+  { href: "/dashboard/projects", label: "Projects", icon: "📁" },
   { href: "/dashboard/review", label: "Review", icon: "🔍" },
 ];
 

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -15,6 +15,24 @@ const DEFAULT_TASKS = [
   { id: 3, text: "Write weekly investor update", done: false },
 ];
 
+// Placeholder weekly stats (realistic founder data)
+const WEEK_BARS = [
+  { day: "M", pct: 100 },
+  { day: "T", pct: 75 },
+  { day: "W", pct: 100 },
+  { day: "T", pct: 50 },
+  { day: "F", pct: 67 },
+  { day: "S", pct: 100 },
+  { day: "S", pct: 33 }, // today — in progress
+];
+
+const STATS = [
+  { label: "Tasks done", value: "18", sub: "this week" },
+  { label: "Deep work", value: "14.5h", sub: "this week" },
+  { label: "Streak", value: "7 days", sub: "current run" },
+  { label: "Reviews", value: "6", sub: "this month" },
+];
+
 export default function DashboardPage() {
   const { user } = useAuth();
   const [tasks, setTasks] = useState(DEFAULT_TASKS);
@@ -47,6 +65,45 @@ export default function DashboardPage() {
         <h1 className="text-2xl font-semibold mt-1">
           Good morning, {user?.name.split(" ")[0]} 👋
         </h1>
+      </div>
+
+      {/* Analytics */}
+      <div className="mb-5">
+        {/* Stat cards */}
+        <div className="grid grid-cols-4 gap-3 mb-3">
+          {STATS.map((s) => (
+            <div
+              key={s.label}
+              className="bg-[#18181b] border border-[#3f3f46] rounded-xl p-4"
+            >
+              <p className="text-[#71717a] text-xs mb-1">{s.label}</p>
+              <p className="text-lg font-semibold leading-none">{s.value}</p>
+              <p className="text-[#52525b] text-[10px] mt-1">{s.sub}</p>
+            </div>
+          ))}
+        </div>
+
+        {/* Mini bar chart — weekly task completion */}
+        <div className="bg-[#18181b] border border-[#3f3f46] rounded-xl p-4">
+          <p className="text-xs text-[#71717a] mb-3">Weekly completion</p>
+          <div className="flex items-end gap-1.5 h-10">
+            {WEEK_BARS.map((b, i) => (
+              <div key={i} className="flex-1 flex flex-col items-center gap-1">
+                <div className="w-full flex items-end" style={{ height: 32 }}>
+                  <div
+                    className={`w-full rounded-sm transition-all ${
+                      i === WEEK_BARS.length - 1
+                        ? "bg-[#7c3aed]/40"
+                        : "bg-[#7c3aed]"
+                    }`}
+                    style={{ height: `${b.pct}%` }}
+                  />
+                </div>
+                <span className="text-[9px] text-[#52525b]">{b.day}</span>
+              </div>
+            ))}
+          </div>
+        </div>
       </div>
 
       {/* Intention */}

--- a/src/app/dashboard/projects/page.tsx
+++ b/src/app/dashboard/projects/page.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useState } from "react";
+
+export default function ProjectsPage() {
+  const [projects] = useState<string[]>([]);
+
+  return (
+    <div className="px-8 py-8 max-w-2xl mx-auto">
+      <div className="flex items-center justify-between mb-8">
+        <div>
+          <h1 className="text-2xl font-semibold">Projects</h1>
+          <p className="text-[#71717a] text-sm mt-1">
+            Track your key initiatives and connect them to your daily plan.
+          </p>
+        </div>
+        <button
+          className="bg-[#7c3aed] hover:bg-[#6d28d9] text-white font-medium px-4 py-2 rounded-md text-sm transition-colors"
+          onClick={() => {}}
+        >
+          + New project
+        </button>
+      </div>
+
+      {projects.length === 0 ? (
+        /* Empty state */
+        <div className="bg-[#18181b] border border-[#3f3f46] rounded-xl p-12 flex flex-col items-center text-center">
+          <div className="w-14 h-14 rounded-2xl bg-[#27272a] flex items-center justify-center mb-4">
+            <svg
+              className="w-7 h-7 text-[#52525b]"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={1.5}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M2.25 12.75V12A2.25 2.25 0 014.5 9.75h15A2.25 2.25 0 0121.75 12v.75m-8.69-6.44l-2.12-2.12a1.5 1.5 0 00-1.061-.44H4.5A2.25 2.25 0 002.25 6v12a2.25 2.25 0 002.25 2.25h15A2.25 2.25 0 0021.75 18V9a2.25 2.25 0 00-2.25-2.25h-5.379a1.5 1.5 0 01-1.06-.44z"
+              />
+            </svg>
+          </div>
+
+          <h2 className="text-base font-semibold mb-2">No projects yet</h2>
+          <p className="text-[#71717a] text-sm max-w-xs mb-6">
+            Projects help you group your big rocks and daily tasks around the
+            initiatives that matter most — fundraising, product, hiring.
+          </p>
+
+          <button
+            className="bg-[#27272a] hover:bg-[#3f3f46] border border-[#3f3f46] text-sm font-medium px-4 py-2 rounded-md transition-colors"
+            onClick={() => {}}
+          >
+            Create your first project
+          </button>
+        </div>
+      ) : null}
+
+      {/* Suggested project types (shown alongside empty state) */}
+      {projects.length === 0 && (
+        <div className="mt-5 grid grid-cols-3 gap-3">
+          {[
+            {
+              icon: "🚀",
+              name: "Product launch",
+              desc: "Ship v2 to early adopters",
+            },
+            {
+              icon: "💰",
+              name: "Fundraising",
+              desc: "Close the seed round",
+            },
+            {
+              icon: "🤝",
+              name: "Hiring",
+              desc: "Build out the founding team",
+            },
+          ].map((t) => (
+            <div
+              key={t.name}
+              className="bg-[#18181b] border border-[#3f3f46] rounded-xl p-4 cursor-pointer hover:border-[#7c3aed]/50 transition-colors group"
+            >
+              <span className="text-xl mb-2 block">{t.icon}</span>
+              <p className="text-sm font-medium group-hover:text-white transition-colors">
+                {t.name}
+              </p>
+              <p className="text-[#52525b] text-xs mt-0.5">{t.desc}</p>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/dashboard/review/page.tsx
+++ b/src/app/dashboard/review/page.tsx
@@ -25,9 +25,17 @@ const QUESTIONS = [
   },
 ];
 
+// Placeholder past reviews — realistic founder copy
+const PAST_REVIEWS: {
+  date: string;
+  wins: string;
+  tomorrow: string;
+}[] = [];
+
 export default function ReviewPage() {
   const [answers, setAnswers] = useState<Record<string, string>>({});
   const [saved, setSaved] = useState(false);
+  const [pastReviews, setPastReviews] = useState(PAST_REVIEWS);
 
   function handleChange(id: string, value: string) {
     setAnswers((prev) => ({ ...prev, [id]: value }));
@@ -35,7 +43,19 @@ export default function ReviewPage() {
   }
 
   function handleSave() {
-    // In a real app, persist to DB
+    const wins = answers["wins"]?.trim();
+    const tomorrow = answers["tomorrow"]?.trim();
+    if (wins || tomorrow) {
+      const today = new Date().toLocaleDateString("en-US", {
+        weekday: "short",
+        month: "short",
+        day: "numeric",
+      });
+      setPastReviews((prev) => [
+        { date: today, wins: wins || "—", tomorrow: tomorrow || "—" },
+        ...prev,
+      ]);
+    }
     setSaved(true);
     setTimeout(() => setSaved(false), 2000);
   }
@@ -93,6 +113,64 @@ export default function ReviewPage() {
           <span className="text-[#34d399] text-sm animate-fade-in">
             ✓ Saved
           </span>
+        )}
+      </div>
+
+      {/* Past Reviews */}
+      <div className="mt-12">
+        <h2 className="text-sm font-semibold mb-4">Past reviews</h2>
+
+        {pastReviews.length === 0 ? (
+          /* Empty state */
+          <div className="bg-[#18181b] border border-[#3f3f46] rounded-xl p-8 flex flex-col items-center text-center">
+            <div className="w-10 h-10 rounded-xl bg-[#27272a] flex items-center justify-center mb-3">
+              <svg
+                className="w-5 h-5 text-[#52525b]"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={1.5}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25"
+                />
+              </svg>
+            </div>
+            <p className="text-sm font-medium mb-1">No past reviews yet</p>
+            <p className="text-[#52525b] text-xs max-w-xs">
+              Complete your first daily review above and it will appear here.
+              Reviews help you spot patterns and track momentum over time.
+            </p>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-3">
+            {pastReviews.map((r, i) => (
+              <div
+                key={i}
+                className="bg-[#18181b] border border-[#3f3f46] rounded-xl p-4"
+              >
+                <p className="text-xs text-[#71717a] mb-2">{r.date}</p>
+                <div className="flex flex-col gap-1.5">
+                  <div>
+                    <span className="text-[10px] text-[#52525b] uppercase tracking-wide">
+                      Wins
+                    </span>
+                    <p className="text-sm text-[#f4f4f5] mt-0.5">{r.wins}</p>
+                  </div>
+                  <div>
+                    <span className="text-[10px] text-[#52525b] uppercase tracking-wide">
+                      Tomorrow
+                    </span>
+                    <p className="text-sm text-[#f4f4f5] mt-0.5">
+                      {r.tomorrow}
+                    </p>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary

- **Analytics stat cards**: Dashboard now shows 4 stat cards (tasks done this week, deep work hours, current streak, reviews this month) plus a mini CSS bar chart visualising daily task completion for the past 7 days — all with realistic founder-flavoured placeholder data.
- **Projects page**: New `/dashboard/projects` route with a polished empty state (icon, headline, description, CTA) and a row of suggested project-type cards (Product launch, Fundraising, Hiring) to make the page feel intentional even before any projects are added. Added "Projects" to the sidebar nav.
- **Review history empty state**: The Review page now has a "Past reviews" section below the form. It shows an empty state with explanation copy until the user saves their first review, at which point the entry is appended to the list (wins + tomorrow's priority).

## Test plan

- [ ] Visit `/dashboard` — verify stat cards and bar chart render correctly
- [ ] Visit `/dashboard/projects` — verify empty state, suggested cards, and sidebar link are present
- [ ] Visit `/dashboard/review` — verify "Past reviews" empty state renders; fill in wins + tomorrow and click "Save review" — verify the entry appears in the list

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Projects navigation to the dashboard sidebar.
  * Added Analytics section displaying key metrics and weekly completion chart on the dashboard.
  * Created new Projects page with empty state and suggested project templates.
  * Added Past reviews section to track and view historical review entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->